### PR TITLE
[stm32f407-explorer]优化Kconfig文件系统命名，SFUD注册w25q128时命名自适应，避免用户多设置一步名称

### DIFF
--- a/bsp/stm32/stm32f407-atk-explorer/board/Kconfig
+++ b/bsp/stm32/stm32f407-atk-explorer/board/Kconfig
@@ -76,7 +76,7 @@ menu "Onboard Peripheral Drivers"
             bool
             default n
 
-        config BSP_USING_SDCARD
+        config BSP_USING_SDCARD_FATFS
             bool "Enable SDCARD (FATFS)"
             select BSP_USING_SDIO
             select RT_USING_DFS
@@ -93,7 +93,7 @@ menu "Onboard Peripheral Drivers"
             default 1000000
 
         config BSP_USING_SPI_FLASH_LITTLEFS
-            bool "Enable LITTLEFS"
+            bool "Enable SPI-FLASH (LittleFS)"
             select RT_USING_DFS
             select RT_USING_DFS_ROMFS
             select RT_USING_MTD_NOR

--- a/bsp/stm32/stm32f407-atk-explorer/board/ports/drv_filesystem.c
+++ b/bsp/stm32/stm32f407-atk-explorer/board/ports/drv_filesystem.c
@@ -28,7 +28,7 @@
 #define DBG_LVL DBG_INFO
 #include <rtdbg.h>
 
-#ifdef BSP_USING_SDCARD
+#ifdef BSP_USING_SDCARD_FATFS
 static void sd_mount(void *parameter)
 {
     while (1)
@@ -84,6 +84,7 @@ static int onboard_spiflash_mount(void)
     struct rt_device *mtd_dev = RT_NULL;
 
     fal_init();
+
     mtd_dev = fal_mtd_nor_device_create(FS_PARTITION_NAME);
     if (!mtd_dev)
     {
@@ -113,7 +114,7 @@ static int onboard_spiflash_mount(void)
 
 static const struct romfs_dirent _romfs_root[] =
 {
-#ifdef BSP_USING_SDCARD
+#ifdef BSP_USING_SDCARD_FATFS
     {ROMFS_DIRENT_DIR, "sdcard", RT_NULL, 0},
 #endif
 
@@ -133,7 +134,7 @@ static int filesystem_mount(void)
     {
         LOG_E("rom mount to '/' failed!");
     }
-#ifdef BSP_USING_SDCARD
+#ifdef BSP_USING_SDCARD_FATFS
     onboard_sdcard_mount();
 #endif
 

--- a/bsp/stm32/stm32f407-atk-explorer/board/ports/spi_flash_init.c
+++ b/bsp/stm32/stm32f407-atk-explorer/board/ports/spi_flash_init.c
@@ -14,12 +14,19 @@
 #include "drv_spi.h"
 
 #if defined(BSP_USING_SPI_FLASH)
+
+#ifdef FAL_USING_NOR_FLASH_DEV_NAME
+#define _SPI_FLASH_NAME FAL_USING_NOR_FLASH_DEV_NAME
+#else
+#define _SPI_FLASH_NAME "W25Q128"
+#endif
+
 static int rt_hw_spi_flash_init(void)
 {
     __HAL_RCC_GPIOB_CLK_ENABLE();
     rt_hw_spi_device_attach("spi1", "spi10", GPIOB, GPIO_PIN_14);
 
-    if (RT_NULL == rt_sfud_flash_probe("W25Q128", "spi10"))
+    if (RT_NULL == rt_sfud_flash_probe(_SPI_FLASH_NAME, "spi10"))
     {
         return -RT_ERROR;
     };


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested.
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [ ] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
